### PR TITLE
Add apply_step_without_grad

### DIFF
--- a/composer/optim/adopt.py
+++ b/composer/optim/adopt.py
@@ -412,6 +412,24 @@ class ADOPT(Optimizer):
 
         return loss
 
+    @torch.no_grad()  # pyright: ignore[reportUntypedFunctionDecorator]
+    def apply_step_without_grad(self):
+        """Apply parameter updates using stored momenta without modifying state."""
+
+        for group in self.param_groups:
+            lr = group['lr']
+            weight_decay = group['weight_decay']
+            initial_lr = group['initial_lr']
+            decouple = group['decouple']
+
+            for p in group['params']:
+                state = self.state[p]
+                if decouple and weight_decay != 0:
+                    decay_factor = (lr / initial_lr) if initial_lr else 1.0
+                    p.mul_(1 - decay_factor * weight_decay)
+
+                p.add_(state['exp_avg'], alpha=-lr)
+
     def dist_reduce_metrics(self, optimizer_metrics):
         local_keys = list(optimizer_metrics.keys())
         all_gathered_keys = dist.all_gather_object(local_keys)


### PR DESCRIPTION
## Summary
- implement `apply_step_without_grad` to apply momentum-based updates without changing optimizer state

## Testing
- `pre-commit run --files composer/optim/adopt.py composer/optim/qhadopt.py composer/optim/decoupled_weight_decay.py` *(installation stalled)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'composer')*

------
https://chatgpt.com/codex/tasks/task_e_68437038df508331a460984c090eceb7